### PR TITLE
Fix broken spec

### DIFF
--- a/autodoc.js
+++ b/autodoc.js
@@ -369,7 +369,13 @@
     // Group by namespace so that we can keep the functions organized.
     var functionsByNamespace = Lazy(functions)
       .groupBy(function(fn) {
-        return fn.namespace || '[private]';
+        if(fn.namespace) {
+          return fn.namespace;
+        } else if (fn.isGlobal) {
+          return fn.shortName;
+        } else {
+          return '[private]';
+        }
       })
       .toObject();
 
@@ -610,6 +616,7 @@
         isCtor      = Autodoc.hasTag(doc, 'constructor'),
         isStatic    = nameInfo.name.indexOf('#') === -1, // That's right, hacky smacky
         isPublic    = Autodoc.hasTag(doc, 'public'),
+        isGlobal    = fn.parent.type === 'Program',
         isPrivate   = Autodoc.hasTag(doc, 'private'),
         signature   = Autodoc.getSignature(nameInfo, params),
         examples    = this.getExamples(doc),
@@ -626,6 +633,7 @@
       params: params,
       returns: returns,
       isConstructor: isCtor,
+      isGlobal: isGlobal,
       isStatic: isStatic,
       isPublic: isPublic,
       isPrivate: isPrivate,

--- a/example/helloWorld.js
+++ b/example/helloWorld.js
@@ -16,6 +16,16 @@ function Foo() {};
  * @returns {string}
  */
 Foo.getName = function() {
+
+  /**
+   * This is some documentation
+   *
+   * @returns {string}
+   */
+  function privateFunction() {
+    return 'this is a private function but it still needs documentation';
+  }
+
   return 'foo';
 };
 

--- a/test/autodoc_test.coffee
+++ b/test/autodoc_test.coffee
@@ -123,7 +123,10 @@ describe 'Autodoc', ->
         data.description.should.match /^\s*<p>This is a description.<\/p>\s*$/
 
       it 'gets all namespaces', ->
-        listNamespaces(data).should.eql ['Foo', 'Foo.Bar']
+        listNamespaces(data).should.contain 'Foo'
+        listNamespaces(data).should.contain 'Foo.Bar'
+        listNamespaces(data).should.not.contain 'privateFunction'
+        listNamespaces(data).should.contain '[private]'
 
       it 'groups functions by namespace', ->
         listMembersForNamespace(data, 'Foo').should.eql ['getName']


### PR DESCRIPTION
Heya! Just noticed that `npm test` fails, so I thought I'd try and fix it. Turns out it's this commit: 2dced03ad9212d999246de337817da479b69a1dc

Anyway, not sure if I really like my fix, but it does make the specs pass and I think it's in the spirit of your direction. What do you think?

I get that we want to list out private functions, but the outer namespace shouldn't be considered a private function should it? Here's a screenshot of the result of `node bin/autodoc example/helloWorld.js` before my fix:

<img src="http://i.imgur.com/UxOCdqL.png">

And here's what it looks like after my fix, with another "private" function added:

<img src="http://i.imgur.com/N6JNK83.png">
